### PR TITLE
Trying to quit with \q; gives an error:

### DIFF
--- a/deployment.sh
+++ b/deployment.sh
@@ -40,7 +40,7 @@ update-rc.d postgresql defaults
 
 echo "### Initializing PostgreSQL test database and table"
 echo "### NOTE: when asked for a password, type 'testpass'"
-echo "Now type: ALTER USER postgres WITH PASSWORD 'testpass'; - hit RETURN, type \q; - hit RETURN"
+echo "Now type: ALTER USER postgres WITH PASSWORD 'testpass'; - hit RETURN, type \q - hit RETURN"
 su postgres -c psql
 passwd -d postgres
 su postgres -c passwd


### PR DESCRIPTION
The help note says:

Now type: ALTER USER postgres WITH PASSWORD 'testpass'; - hit RETURN, type \q; 

but you don't want the ; on the end otherwise it gives you:

postgres=# \q;
Invalid command \q;. Try \? for help.

Quit Postgres with \q not \q;
